### PR TITLE
remove llvm

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -39,7 +39,7 @@ class Mesa(MesonPackage):
     depends_on('zlib@1.2.3:')
 
     # Internal options
-    variant('llvm', default=True, description="Enable LLVM.")
+    variant('llvm', default=False, description="Enable LLVM.")
     _SWR_AUTO_VALUE = 'auto'
     _SWR_ENABLED_VALUES = (_SWR_AUTO_VALUE, 'avx', 'avx2', 'knl', 'skx')
     _SWR_DISABLED_VALUES = ('none',)


### PR DESCRIPTION
Set llvm as False by default in mesa package, which saves a ton of disk space (especially when compiling with -g).

A change need to be added to recipe, adding explicitly opengl to the root spec (which otherwise gets dropped):
`^root@6.22.08  ~root7+davix+fits+fortran~mysql+sqlite+postgres+python+ssl+xrootd+fftw+pythia6+tmva+mlp+vmc+spectrum+opengl`